### PR TITLE
Unsafe vector lookup optimisation

### DIFF
--- a/src/HaskellWorks/Data/Excess/MinMaxExcess0.hs
+++ b/src/HaskellWorks/Data/Excess/MinMaxExcess0.hs
@@ -57,9 +57,9 @@ instance MinMaxExcess0 (Naive Word64) where
   {-# INLINE minMaxExcess0 #-}
 
 instance MinMaxExcess0 Word8 where
-  minMaxExcess0 w = Triplet (word8Excess0Min DVS.! fromIntegral w)
-                            (word8Excess0    DVS.! fromIntegral w)
-                            (word8Excess0Max DVS.! fromIntegral w)
+  minMaxExcess0 w = Triplet (DVS.unsafeIndex word8Excess0Min (fromIntegral w))
+                            (DVS.unsafeIndex word8Excess0    (fromIntegral w))
+                            (DVS.unsafeIndex word8Excess0Max (fromIntegral w))
   {-# INLINE minMaxExcess0 #-}
 
 instance MinMaxExcess0 Word16 where

--- a/src/HaskellWorks/Data/Excess/MinMaxExcess1.hs
+++ b/src/HaskellWorks/Data/Excess/MinMaxExcess1.hs
@@ -57,9 +57,9 @@ instance MinMaxExcess1 (Naive Word64) where
   {-# INLINE minMaxExcess1 #-}
 
 instance MinMaxExcess1 Word8 where
-  minMaxExcess1 w = Triplet (word8Excess1Min DVS.! fromIntegral w)
-                            (word8Excess1    DVS.! fromIntegral w)
-                            (word8Excess1Max DVS.! fromIntegral w)
+  minMaxExcess1 w = Triplet (DVS.unsafeIndex word8Excess1Min  (fromIntegral w))
+                            (DVS.unsafeIndex word8Excess1     (fromIntegral w))
+                            (DVS.unsafeIndex word8Excess1Max  (fromIntegral w))
   {-# INLINE minMaxExcess1 #-}
 
 instance MinMaxExcess1 Word16 where


### PR DESCRIPTION
Before:

```
benchmarking MinMaxExcess Vector/MinMaxExcess0
time                 6.355 ms   (6.247 ms .. 6.461 ms)
                     0.998 R²   (0.996 R² .. 0.999 R²)
mean                 6.348 ms   (6.292 ms .. 6.416 ms)
std dev              182.4 μs   (160.9 μs .. 219.5 μs)
variance introduced by outliers: 10% (moderately inflated)

benchmarking MinMaxExcess Vector/MinMaxExcess1
time                 6.283 ms   (6.214 ms .. 6.389 ms)
                     0.997 R²   (0.993 R² .. 0.999 R²)
mean                 6.406 ms   (6.350 ms .. 6.482 ms)
std dev              196.3 μs   (150.4 μs .. 291.2 μs)
variance introduced by outliers: 13% (moderately inflated)
```

After:

```
benchmarking MinMaxExcess Vector/MinMaxExcess0
time                 5.302 ms   (5.224 ms .. 5.357 ms)
                     0.999 R²   (0.998 R² .. 0.999 R²)
mean                 5.370 ms   (5.327 ms .. 5.417 ms)
std dev              136.9 μs   (114.1 μs .. 175.1 μs)

benchmarking MinMaxExcess Vector/MinMaxExcess1
time                 5.537 ms   (5.461 ms .. 5.619 ms)
                     0.998 R²   (0.997 R² .. 0.999 R²)
mean                 5.480 ms   (5.428 ms .. 5.528 ms)
std dev              154.0 μs   (129.5 μs .. 184.0 μs)
variance introduced by outliers: 12% (moderately inflated)
```